### PR TITLE
LPS-45506 Update calendar booking Modified Date while adding or deleting a recurrence exception

### DIFF
--- a/portlets/calendar-portlet/docroot/WEB-INF/src/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/portlets/calendar-portlet/docroot/WEB-INF/src/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -318,6 +318,8 @@ public class CalendarBookingLocalServiceImpl
 			boolean allFollowing)
 		throws PortalException, SystemException {
 
+		Date now = new Date();
+
 		java.util.Calendar startTimeJCalendar = JCalendarUtil.getJCalendar(
 			startTime);
 
@@ -349,6 +351,7 @@ public class CalendarBookingLocalServiceImpl
 			calendarBooking.getCalendarBookingId());
 
 		for (CalendarBooking childCalendarBooking : childCalendarBookings) {
+			childCalendarBooking.setModifiedDate(now);
 			childCalendarBooking.setRecurrence(recurrence);
 
 			calendarBookingPersistence.update(childCalendarBooking);


### PR DESCRIPTION
Hi Adam! Hope everything is fine :smile:
While working on some synchronization engines for the Calendar portlet, I realized it's not so easy to find when a booking recurrence has changed: I'd like to use dynamic queries to find created and updated bookings, but the `modifiedDate` value isn't updated when a recurrence is changed. Do you think it's possible to add this very small but useful functionality? :blush:
