### PR TITLE
[Technical-Support] LPS-52000 Daily repeated event doesn't show up on every days of month view

### DIFF
--- a/portlets/calendar-portlet/docroot/js/javascript.js
+++ b/portlets/calendar-portlet/docroot/js/javascript.js
@@ -1227,7 +1227,7 @@ AUI.add(
 						date = DateMath.add(date, DateMath.MONTH, 1);
 					}
 					else if (viewName === 'month') {
-						date = DateMath.add(date, DateMath.WEEK, 1);
+						date = DateMath.add(date, DateMath.WEEK, 2);
 					}
 
 					return CalendarUtil.toUTC(date);

--- a/portlets/ddl-form-portlet/docroot/view.jsp
+++ b/portlets/ddl-form-portlet/docroot/view.jsp
@@ -87,7 +87,7 @@ try {
 									/>
 
 									<aui:button-row>
-										<aui:button onClick='<%= renderResponse.getNamespace() + "publishRecord();" %>' type="submit" value="send" />
+										<aui:button type="submit" value="send" />
 									</aui:button-row>
 								</aui:fieldset>
 							</c:when>


### PR DESCRIPTION
Hi Adam,

Zsolt Olah has a simple fix for this issue.
Month view of Calendar portlet shows always 42 days thus sometimes we need to extends the number of days with 2 weeks instead of 1 week.
I guess this is not the best solution for this issue but this solution can resolve that.

Thanks,
 Zsaga