### PR TITLE
LPS-52965 Calendar: Event creator gets duplicated notifications.

### DIFF
--- a/portlets/calendar-portlet/docroot/WEB-INF/src/com/liferay/calendar/util/NotificationUtil.java
+++ b/portlets/calendar-portlet/docroot/WEB-INF/src/com/liferay/calendar/util/NotificationUtil.java
@@ -214,13 +214,13 @@ public class NotificationUtil {
 		throws Exception {
 
 		List<NotificationRecipient> notificationRecipients = new ArrayList<>();
+		Set<User> users = new HashSet<>();
 
+		Calendar calendar = calendarBooking.getCalendar();
 		CalendarResource calendarResource =
 			calendarBooking.getCalendarResource();
 
-		Set<User> users = new HashSet<>();
-
-		users.add(UserLocalServiceUtil.getUser(calendarBooking.getUserId()));
+		users.add(UserLocalServiceUtil.getUser(calendar.getUserId()));
 		users.add(UserLocalServiceUtil.getUser(calendarResource.getUserId()));
 
 		for (User user : users) {

--- a/portlets/calendar-portlet/docroot/js/components.js
+++ b/portlets/calendar-portlet/docroot/js/components.js
@@ -863,7 +863,7 @@
 							elements.set('disabled', !checked);
 
 							if (checked) {
-								elements.first().selectText();
+								elements.first().select();
 							}
 						},
 


### PR DESCRIPTION
Hey Adam

Again, Ogilvy discovered a regression bug LPS-52965  caused by your LPS-53074.

We should use ``calendar.getUserId()``, instead of ``calendarBooking.getUserId()``, to follow the original logic.

Please help reviewing .

Thanks
John.