### PR TITLE
LPS-54625 wrong styling of current week in mini calendar: grey bend which shows the current week is not always complete

### DIFF
--- a/portlets/calendar-portlet/docroot/view_calendar.jsp
+++ b/portlets/calendar-portlet/docroot/view_calendar.jsp
@@ -407,13 +407,13 @@ boolean columnOptionsVisible = GetterUtil.getBoolean(SessionClicks.get(request, 
 			Liferay.CalendarUtil.toUTC(miniCalendarEndDate),
 			'busy',
 			function(rulesDefinition) {
+				var selectedDates = <portlet:namespace />miniCalendar._getSelectedDatesList();
+
 				window.<portlet:namespace />miniCalendar.set(
 					'customRenderer',
 					{
 						filterFunction: function(date, node, rules) {
 							node.addClass('lfr-busy-day');
-
-							var selectedDates = this._getSelectedDatesList();
 
 							DateMath.toMidnight(date);
 
@@ -428,6 +428,8 @@ boolean columnOptionsVisible = GetterUtil.getBoolean(SessionClicks.get(request, 
 						rules: rulesDefinition
 					}
 				);
+
+				<portlet:namespace />miniCalendar.selectDates(selectedDates);
 			}
 		);
 	};


### PR DESCRIPTION
Hey Adam,

Could you please review this pull?

It is forwarded from https://github.com/IstvanD/liferay-plugins/pull/9

The explanation about the issue is in the LPS.

Thank you.

Best regards,
István