### PR TITLE
LPS-55080 Calendar portlet, weekdays in the mini calendar are not affected by calendar's 'Week Starts On' configuration

### DIFF
--- a/portlets/calendar-portlet/docroot/edit_calendar_booking.jsp
+++ b/portlets/calendar-portlet/docroot/edit_calendar_booking.jsp
@@ -173,11 +173,11 @@ for (long otherCalendarId : otherCalendarIds) {
 		<aui:input defaultLanguageId="<%= themeDisplay.getLanguageId() %>" name="title" />
 
 		<div class="<%= allDay ? "allday-class-active" : "" %>" id="<portlet:namespace />startDateContainer">
-			<aui:input ignoreRequestValue="<%= true %>" label="start-date" name="startTime" value="<%= startTimeJCalendar %>" />
+			<aui:input ignoreRequestValue="<%= true %>" label="start-date" name="startTime" value="<%= startTimeJCalendar %>" firstDayOfWeek="<%= weekStartsOn %>" />
 		</div>
 
 		<div class="<%= allDay ? "allday-class-active" : "" %>" id="<portlet:namespace />endDateContainer">
-			<aui:input ignoreRequestValue="<%= true %>" label="end-date" name="endTime" value="<%= endTimeJCalendar %>" />
+			<aui:input ignoreRequestValue="<%= true %>" label="end-date" name="endTime" value="<%= endTimeJCalendar %>" firstDayOfWeek="<%= weekStartsOn %>" />
 		</div>
 
 		<aui:input checked="<%= allDay %>" name="allDay" />


### PR DESCRIPTION
Hey @brandizzi 

Could you please review this pull?

The branch of the portal side counterpart is:
https://github.com/IstvanD/liferay-portal-ee/commits/fix-pack-LPP-16177

However, it will be provided as SDH, so it is based on ee-6.2.10-sp10.

Thank you.

Best regards,
István