### PR TITLE
[Technical-Support] LPS-55392 Calendar: Incorrect display of overnight events in Week and Da...

### DIFF
--- a/portlets/calendar-portlet/docroot/js/javascript.js
+++ b/portlets/calendar-portlet/docroot/js/javascript.js
@@ -1252,7 +1252,7 @@ AUI.add(
 						date = DateMath.add(date, DateMath.WEEK, 1);
 					}
 
-					return CalendarUtil.toUTC(date);
+					return date;
 				},
 
 				getLoadStartDate: function(activeView) {
@@ -1267,7 +1267,7 @@ AUI.add(
 						date = DateMath.subtract(date, DateMath.WEEK, 1);
 					}
 
-					return CalendarUtil.toUTC(date);
+					return date;
 				},
 
 				_doRead: function(options, callback) {


### PR DESCRIPTION
Hi Adam,

Firstly, thanks a lot for you help Support. I saw you pull for LPS-50357 and I'm going to check it today afternoon.

Regarding of this issue you can check the given common reproduction steps on LPS-55392.

I found that Scheduler and Scheduler view components always use browser timezone for rendering different views (specially columns) but the received events's startDate and endDate are showed based on User's timezone.

This issue is causing because when Calendar sends a resource request to server-side we convert current view's startTime and endTime to UTC. In this case there are some special cases (it depends on user timezone, event's startDate - endDate and browser's timezone) when the event's filtering for current view based on sent starTime and endTime won't be correct.

I know that is a curious issue again and I had to test and debug Calendar behavior for two days I could decide heavily that server-side or client-side codes are responsible this mistake. At the end I think on server-side everything ok and after my changes on client-side Calendar portlet works properly in different timezones as well.

Please let me know that you would have any concern regarding my solution.

Thanks again,
 Zsaga